### PR TITLE
Fix server banner cut to 1/4 of image

### DIFF
--- a/roundmoledV2.theme.css
+++ b/roundmoledV2.theme.css
@@ -57,10 +57,6 @@
   background-color: var(--dark-primary);
 }
 
-.scroller_c43953 {
-  background-color: var(--dark-secondary);
-}
-
 .sidebar_a4d4d9,
 .platform-win .sidebar_a4d4d9,
 .layers_a01fb1,
@@ -2016,4 +2012,8 @@ dcvarsp
 
 .content-yjf30S {
   background-color: var(--dark-secondary-alt);
+}
+
+.theme-dark .container_ee69e0 {
+  background-color: var(--dark-secondary);
 }


### PR DESCRIPTION
Fixes #1

Remove the CSS rule for `.scroller_c43953` that sets the `background-color` to `var(--dark-secondary)`.

Add a new CSS rule for `.theme-dark .container_ee69e0` that sets the `background-color` to `var(--dark-secondary)`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/TheoEwzZer/RoundmoledV2/issues/1?shareId=cb6c1547-3004-4a87-a6d7-31462d214361).

## Summary by Sourcery

Bug Fixes:
- Fix the issue where the server banner was cut to a quarter of the image by adjusting CSS rules.